### PR TITLE
Allows event.features to be passed up without null check

### DIFF
--- a/custom_components/reflex_map/maplibre_react.py
+++ b/custom_components/reflex_map/maplibre_react.py
@@ -6,7 +6,7 @@ def get_maplibre_js():
     return """
     const extractSafeEvent = (event) => {
       return {
-        features: event.features.length ? event.features : null,
+        features: event.features,
         lngLat: event.lngLat,
         point: event.point,
         originalEvent: event.originalEvent,


### PR DESCRIPTION
Tiny change to remove a null pass into our events for reflex